### PR TITLE
Improve scale pad for more aspect mixes and fix tests

### DIFF
--- a/lib/ffmpegCommandService.js
+++ b/lib/ffmpegCommandService.js
@@ -541,7 +541,7 @@ class FfmpegCommandService {
     }
 
     _createFilterForTextOverlay(textOverlay, i, command) {
-        const bashCharsToEscapeRegex = /!|"/g;
+        const bashCharsToEscapeRegex = /!|"|:/g;
 
         // @TODO: add handling for escaping special characters in bash.  Know it's at least ! that needs escaping.
         const text = textOverlay.text

--- a/lib/ffmpegCommandService.js
+++ b/lib/ffmpegCommandService.js
@@ -374,12 +374,12 @@ class FfmpegCommandService {
         command.video.forEach((video,i) => {
             filter += ` [${i}:v]`; // start
 
+            // Scale videos to the same size (setsar=1 recommended to coax aspect ratios, may not be needed anymore)
+            filter += ` scale=${outWidth}:${outHeight}:force_original_aspect_ratio=decrease, setsar=1,`;
+
             // Force padding for videos not in the correct aspect ratio ih=inputHeight, oh=outputHeight, etc
             // See examples https://ffmpeg.org/ffmpeg-filters.html#pad-1
             filter += ` pad=ih*${ratio}/sar:ih:(ow-iw)/2:(oh-ih)/2,`;
-
-            // Scale videos to the same size (setsar=1 recommended to coax aspect ratios, may not be needed anymore)
-            filter += ` scale=${outWidth}:${outHeight}:force_original_aspect_ratio=decrease, setsar=1,`;
 
             // setpts=PTS-STARTPTS ensures trimming at an appropriate frame
             // See https://ffmpeg.org/ffmpeg-filters.html#setpts_002c-asetpts

--- a/lib/ffmpegCommandService.js
+++ b/lib/ffmpegCommandService.js
@@ -374,7 +374,8 @@ class FfmpegCommandService {
         command.video.forEach((video,i) => {
             filter += ` [${i}:v]`; // start
 
-            // Scale videos to the same size (setsar=1 recommended to coax aspect ratios, may not be needed anymore)
+            // Scale videos to the same size (this must be done first or videos with wider aspect ratios will fail)
+            // TODO: setsar=1 recommended to coax aspect ratios, verify its still needed
             filter += ` scale=${outWidth}:${outHeight}:force_original_aspect_ratio=decrease, setsar=1,`;
 
             // Force padding for videos not in the correct aspect ratio ih=inputHeight, oh=outputHeight, etc


### PR DESCRIPTION
This changes how we pad/scale videos by scaling the video before padding. Otherwise pad will error out. Especially if the aspect ratio is wider and shorter than the output.

This also fixes all of the tests and improves on how they are written to make it easier to update for the next time.